### PR TITLE
LoadFontFace returns an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ DrawStringWrapped(s string, x, y, ax, ay, width, lineSpacing float64, align Alig
 MeasureString(s string) (w, h float64)
 WordWrap(s string, w float64) []string
 SetFontFace(fontFace font.Face)
-LoadFontFace(path string, points float64)
+LoadFontFace(path string, points float64) error
 ```
 
 ## Color Functions

--- a/context.go
+++ b/context.go
@@ -555,14 +555,13 @@ func (dc *Context) SetFontFace(fontFace font.Face) {
 	dc.fontFace = fontFace
 }
 
-func (dc *Context) LoadFontFace(path string, points float64) {
-	if face, err := loadFontFace(path, points); err == nil {
+func (dc *Context) LoadFontFace(path string, points float64) error {
+	face, err := loadFontFace(path, points)
+	if err == nil {
 		dc.fontFace = face
 		dc.fontHeight = points * 72 / 96
-	} else {
-		dc.fontFace = basicfont.Face7x13
-		dc.fontHeight = 13
-	}
+	} 
+	return err
 }
 
 func (dc *Context) drawString(im *image.RGBA, s string, x, y float64) {

--- a/examples/meme.go
+++ b/examples/meme.go
@@ -7,7 +7,9 @@ func main() {
 	dc := gg.NewContext(S, S)
 	dc.SetRGB(1, 1, 1)
 	dc.Clear()
-	dc.LoadFontFace("/Library/Fonts/Impact.ttf", 96)
+	if err := dc.LoadFontFace("/Library/Fonts/Impact.ttf", 96); err != nil {
+		panic(err)
+	}
 	dc.SetRGB(0, 0, 0)
 	s := "ONE DOES NOT SIMPLY"
 	n := 6 // "stroke" size

--- a/examples/scatter.go
+++ b/examples/scatter.go
@@ -54,9 +54,13 @@ func main() {
 	// draw text
 	dc.Identity()
 	dc.SetRGB(0, 0, 0)
-	dc.LoadFontFace("/Library/Fonts/Arial Bold.ttf", 24)
+	if err := dc.LoadFontFace("/Library/Fonts/Arial Bold.ttf", 24); err != nil {
+		panic(err)
+	}
 	dc.DrawStringAnchored("Chart Title", S/2, P/2, 0.5, 0.5)
-	dc.LoadFontFace("/Library/Fonts/Arial.ttf", 18)
+	if err := dc.LoadFontFace("/Library/Fonts/Arial.ttf", 18); err != nil {
+		panic(err)
+	}
 	dc.DrawStringAnchored("X Axis Title", S/2, S-P/2, 0.5, 0.5)
 	dc.SavePNG("out.png")
 }

--- a/examples/text.go
+++ b/examples/text.go
@@ -8,7 +8,9 @@ func main() {
 	dc.SetRGB(1, 1, 1)
 	dc.Clear()
 	dc.SetRGB(0, 0, 0)
-	dc.LoadFontFace("/Library/Fonts/Arial.ttf", 96)
+	if err := dc.LoadFontFace("/Library/Fonts/Arial.ttf", 96); err != nil {
+		panic(err)
+	}
 	dc.DrawStringAnchored("Hello, world!", S/2, S/2, 0.5, 0.5)
 	dc.SavePNG("out.png")
 }

--- a/examples/wrap.go
+++ b/examples/wrap.go
@@ -18,7 +18,9 @@ func main() {
 	dc.SetLineWidth(3)
 	dc.Stroke()
 	dc.SetRGB(0, 0, 0)
-	dc.LoadFontFace("/Library/Fonts/Arial Bold.ttf", 18)
+	if err := dc.LoadFontFace("/Library/Fonts/Arial Bold.ttf", 18); err != nil {
+		panic(err)
+	}
 	dc.DrawStringWrapped("UPPER LEFT", P, P, 0, 0, 0, 1.5, gg.AlignLeft)
 	dc.DrawStringWrapped("UPPER RIGHT", W-P, P, 1, 0, 0, 1.5, gg.AlignRight)
 	dc.DrawStringWrapped("BOTTOM LEFT", P, H-P, 0, 1, 0, 1.5, gg.AlignLeft)
@@ -27,7 +29,9 @@ func main() {
 	dc.DrawStringWrapped("LOWER MIDDLE", W/2, H-P, 0.5, 1, 0, 1.5, gg.AlignCenter)
 	dc.DrawStringWrapped("LEFT MIDDLE", P, H/2, 0, 0.5, 0, 1.5, gg.AlignLeft)
 	dc.DrawStringWrapped("RIGHT MIDDLE", W-P, H/2, 1, 0.5, 0, 1.5, gg.AlignRight)
-	dc.LoadFontFace("/Library/Fonts/Arial.ttf", 12)
+	if err := dc.LoadFontFace("/Library/Fonts/Arial.ttf", 12); err != nil {
+		panic(err)  
+	}
 	dc.DrawStringWrapped(TEXT, W/2-P, H/2-P, 1, 1, W/3, 1.75, gg.AlignLeft)
 	dc.DrawStringWrapped(TEXT, W/2+P, H/2-P, 0, 1, W/3, 2, gg.AlignLeft)
 	dc.DrawStringWrapped(TEXT, W/2-P, H/2+P, 1, 0, W/3, 2.25, gg.AlignLeft)


### PR DESCRIPTION
Changed `LoadFontFace(path string, points float64)` to return an `error` if the function failes to load the specified font file.
Adapted all (font loading) examples to cater for the changed function.

Fixes #5 

