### PR TITLE
Restore previous state in Context.Pop()

### DIFF
--- a/context.go
+++ b/context.go
@@ -782,10 +782,9 @@ func (dc *Context) Push() {
 
 // Pop restores the last saved context state from the stack.
 func (dc *Context) Pop() {
-	before := *dc
 	s := dc.stack
-	x, s := s[len(s)-1], s[:len(s)-1]
-	*dc = *x
+	before, s := s[len(s)-1], s[:len(s)-1]
+	*dc = *before
 	dc.mask = before.mask
 	dc.strokePath = before.strokePath
 	dc.fillPath = before.fillPath


### PR DESCRIPTION
Fixes #27.