### PR TITLE
Start copying at bounds min instead of zero point

### DIFF
--- a/util.go
+++ b/util.go
@@ -54,8 +54,9 @@ func SavePNG(path string, im image.Image) error {
 }
 
 func imageToRGBA(src image.Image) *image.RGBA {
-	dst := image.NewRGBA(src.Bounds())
-	draw.Draw(dst, dst.Rect, src, image.ZP, draw.Src)
+	bounds := src.Bounds()
+	dst := image.NewRGBA(bounds)
+	draw.Draw(dst, bounds, src, bounds.Min, draw.Src)
 	return dst
 }
 


### PR DESCRIPTION
This makes it possible to create a context from an image that is returned by `other.SubImage(rect)`.

Here is a case that demonstrates the problem with the current `imageToRGBA` func (no error handling for brevity):
```go
package main

import (
	"image"
	"image/png"
	"os"

	"github.com/fogleman/gg"
)

func main() {
	file, _ := os.Open("tile.png")
	im, _ := png.Decode(file)

	rgba := im.(*image.RGBA)

	cropped := rgba.SubImage(image.Rect(30, 40, 246, 246))

	file, _ = os.Create("cropped.png")
	png.Encode(file, cropped)

	file, _ = os.Create("gg.png")
	png.Encode(file, gg.NewContextForImage(cropped).Image())
}
```

With this `tile.png`:

![tile](https://raw.githubusercontent.com/tschaub/test-gg/master/tile.png)

This is the `cropped.png` (expected):

![cropped](https://raw.githubusercontent.com/tschaub/test-gg/master/cropped.png)

And this is the `gg.png` (unexpected):

![gg](https://raw.githubusercontent.com/tschaub/test-gg/master/gg.png)

Here is a repo that demonstrates the issue: https://github.com/tschaub/test-gg