### PR TITLE
Allows the ability to get the current point in the context

### DIFF
--- a/context.go
+++ b/context.go
@@ -110,6 +110,15 @@ func NewContextForRGBA(im *image.RGBA) *Context {
 	}
 }
 
+// GetCurrentPoint will return the current point and if there is a current point.
+// The point will have been transformed by the context's transformation matrix.
+func (dc *Context) GetCurrentPoint() (Point, bool) {
+	if dc.hasCurrent {
+		return dc.current, true
+	}
+	return Point{}, false
+}
+
 // Image returns the image that has been drawn by this context.
 func (dc *Context) Image() image.Image {
 	return dc.im


### PR DESCRIPTION
I'm working on a hobby project that is taking in SVG data. It sticks it into gg and generates an image from the data. However, there's a few cases where getting the current point is helpful. I'm not sure returning an error on 'no current point' makes sense.

A particular case this is helpful for is sometimes SVGs may use relative coordinates in their instructions. Functions like `CubicTo` and a other drawing functions take in absolutes. This change allows me to do the draw commands with relative instructions on my end without too many differences to the current gg. 

Keeping track of the current point outside of gg is possible, but can be tricky with the previous problem mentioned of the absolute and relative coordinates. Also, gg already has the information. :P

Another alternative is drawing functions with relative coordinates, but that's a lot of extra functions.