### PR TITLE
Update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Alternatively, you may use gopkg.in to grab a specific major-version:
 
 ## Documentation
 
-https://godoc.org/github.com/fogleman/gg
+godoc: https://godoc.org/github.com/fogleman/gg
+pkg.go.dev: https://pkg.go.dev/github.com/fogleman/gg?tab=doc
 
 ## Hello, Circle!
 


### PR DESCRIPTION
When visiting the godoc link, a banner at the top informs me that "pkg.go.dev is a new destination for Go discovery and docs". While it doesn't look like godoc is going away, I figured it would be nice to link to both sites.