### PR TITLE
Preserve empty lines in wordWrap

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -28,6 +28,10 @@ func splitOnSpace(x string) []string {
 func wordWrap(m measureStringer, s string, width float64) []string {
 	var result []string
 	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) == "" {
+			result = append(result, line)
+			continue
+		}
 		fields := splitOnSpace(line)
 		if len(fields)%2 == 1 {
 			fields = append(fields, "")


### PR DESCRIPTION
At the moment, word wrap inputs which contain multiple newlines in a row lose empty lines in the output, this PR fixes such behavior.