### PR TITLE
Add method to parse font from byte array

### DIFF
--- a/context.go
+++ b/context.go
@@ -703,6 +703,15 @@ func (dc *Context) LoadFontFace(path string, points float64) error {
 	return err
 }
 
+func (dc *Context) LoadFontFaceFromBytes(fontData []byte, points float64) error {
+	face, err := LoadFontFaceFromBytes(fontData, points)
+	if err == nil {
+		dc.fontFace = face
+		dc.fontHeight = points * 72 / 96
+	}
+	return err
+}
+
 func (dc *Context) FontHeight() float64 {
 	return dc.fontHeight
 }

--- a/util.go
+++ b/util.go
@@ -134,6 +134,14 @@ func LoadFontFace(path string, points float64) (font.Face, error) {
 	if err != nil {
 		return nil, err
 	}
+	face, err := LoadFontFaceFromBytes(fontBytes, points)
+	if err != nil {
+		return nil, err
+	}
+	return face, nil
+}
+
+func LoadFontFaceFromBytes(fontBytes []byte, points float64) (font.Face, error) {
 	f, err := truetype.Parse(fontBytes)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When packaging a golang project using gg that is working with fonts, one may desire to include the font as part of the project as opposed to relying on the font to be installed on the host system.  This is particularly apparent when running in environments such as AWS Lambda.  To address this, allow passing of the font face data as a byte array alongside the existing capability to load from a file path.  This way the font can be stored as a binary blob in the project and loaded dynamically.