### PR TITLE
Support for fs.FS (for embedded files, ideally) and module support

### DIFF
--- a/context.go
+++ b/context.go
@@ -8,6 +8,7 @@ import (
 	"image/jpeg"
 	"image/png"
 	"io"
+	"io/fs"
 	"math"
 	"strings"
 
@@ -695,7 +696,16 @@ func (dc *Context) SetFontFace(fontFace font.Face) {
 }
 
 func (dc *Context) LoadFontFace(path string, points float64) error {
-	face, err := LoadFontFace(path, points)
+	face, err := LoadFontFace(nil, path, points)
+	if err == nil {
+		dc.fontFace = face
+		dc.fontHeight = points * 72 / 96
+	}
+	return err
+}
+
+func (dc *Context) LoadFontFaceFS(fS fs.FS, path string, points float64) error {
+	face, err := LoadFontFace(fS, path, points)
 	if err == nil {
 		dc.fontFace = face
 		dc.fontHeight = points * 72 / 96

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/fogleman/gg
+
+go 1.18
+
+require (
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	golang.org/x/image v0.0.0-20220413100746-70e8d0d3baa9
+)

--- a/util.go
+++ b/util.go
@@ -164,7 +164,7 @@ func unfix(x fixed.Int26_6) float64 {
 func LoadFontFace(fS fs.FS, path string, points float64) (font.Face, error) {
 	var fontBytes []byte
 	var err error
-	if fS != nil {
+	if fS == nil {
 		fontBytes, err = ioutil.ReadFile(path)
 	} else {
 		fp, err := fS.Open(path)


### PR DESCRIPTION
This adds support for fs.FS filesystems (which are used for go:embed directives, etc) as well as go module support.