### PR TITLE
Check errors from Close method in SavePNG and SaveJPG

### DIFF
--- a/util.go
+++ b/util.go
@@ -50,8 +50,10 @@ func SavePNG(path string, im image.Image) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-	return png.Encode(file, im)
+	if err := png.Encode(file, im); err != nil {
+		return err
+	}
+	return file.Close()
 }
 
 func LoadJPG(path string) (image.Image, error) {
@@ -68,12 +70,14 @@ func SaveJPG(path string, im image.Image, quality int) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
 	var opt jpeg.Options
 	opt.Quality = quality
 
-	return jpeg.Encode(file, im, &opt)
+	if err := jpeg.Encode(file, im, &opt); err != nil {
+		return err
+	}
+	return file.Close()
 }
 
 func imageToRGBA(src image.Image) *image.RGBA {


### PR DESCRIPTION
When closing the file, errors can still occur that might not be surfaced during the writes from `png.Encode` and `jpeg.Encode`. By returning the error from `file.Close()`, these cases can be caught.