### PR TITLE
Changes default LineCap style to LineCapButt for correct Circle/Ellipse drawing

### DIFF
--- a/context.go
+++ b/context.go
@@ -21,8 +21,8 @@ import (
 type LineCap int
 
 const (
-	LineCapRound LineCap = iota
-	LineCapButt
+	LineCapButt LineCap = iota
+	LineCapRound
 	LineCapSquare
 )
 


### PR DESCRIPTION
fix for #191 
Changes the default style to LineCapButt. This is a workaround, if SetLineCapRound() is set the Circle will be drawn incorrectly. This style must belong to Circle/Ellipse.